### PR TITLE
stopped supporting cuda 11. unpinned scipy and jax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,17 +18,8 @@ install_requires =
     optree
 
 [options.extras_require]
-cuda11 = 
-    jax==0.3.22
-    etils==1.5.2
-    scipy==1.11.3
-    chex==0.1.6
-    jaxtyping==0.2.14
-    tensorflow_probability==0.19.0
-
-cuda12 =
-    jax>=0.4.16
-    scipy==1.12.0
+cuda = 
+    jax[cuda12]
 
 [options.package_data]
 * = *.md


### PR DESCRIPTION
Stop supporting cuda11, which allows us to un-pin versions for several libraries and simplify setup options. Change made in conjunction with an update to keypoint-moseq so that the installation process is compatible.